### PR TITLE
refactor: 여행지 생성 시, 여행지_방문지_관광지 함께 생성 가능하도록 수정

### DIFF
--- a/src/main/java/com/mju/lighthouseai/domain/travel/controller/TravelController.java
+++ b/src/main/java/com/mju/lighthouseai/domain/travel/controller/TravelController.java
@@ -16,6 +16,9 @@ import com.mju.lighthouseai.domain.travel_visitor_shoppingmall.dto.controller.Tr
 import com.mju.lighthouseai.domain.travel_visitor_shoppingmall.dto.service.request.TravelVisitorShoppingMallCreateServiceRequestDto;
 import com.mju.lighthouseai.domain.travel_visitor_shoppingmall.mapper.dto.TravelVisitorShoppingMallDtoMapper;
 import com.mju.lighthouseai.domain.travel_visitor_shoppingmall.mapper.service.TravelVisitorShoppingMallEntityMapper;
+import com.mju.lighthouseai.domain.travel_visitor_tour_list.dto.controller.TravelVisitorTourListCreateControllerRequestDto;
+import com.mju.lighthouseai.domain.travel_visitor_tour_list.dto.service.request.TravelVisitorTourListCreateServiceRequestDto;
+import com.mju.lighthouseai.domain.travel_visitor_tour_list.mapper.dto.TravelVisitorTourListDtoMapper;
 import com.mju.lighthouseai.domain.user.entity.User;
 import com.mju.lighthouseai.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
@@ -41,6 +44,7 @@ public class TravelController {
     private final TravelService travelService;
     private final TravelVisitorRestaurantDtoMapper travelVisitorRestaurantDtoMapper;
     private final TravelVisitorShoppingMallDtoMapper travelVisitorShoppingMallDtoMapper;
+    private final TravelVisitorTourListDtoMapper travelVisitorTourListDtoMapper;
     @PostMapping("/create")
     public ResponseEntity<?> createTravelVisitorCafe(
         @Valid @RequestPart(name = "travelCreateRequestDto") TravelCreateControllerRequestDto travelCreateControllerRequestDto,
@@ -51,6 +55,8 @@ public class TravelController {
         @RequestPart(name = "TravelVisitorRestaurantImage",required = false) List<MultipartFile> TravelVisitorRestaurantImage,
         @Valid @RequestPart(name = "TravelVisitorShoppingMallCreateServiceRequestDto") List<TravelVisitorShoppingMallCreateControllerRequestDto> TravelVisitorShoppingMallCreateControllerRequestDto,
         @RequestPart(name = "TravelVisitorShoppingMallImage",required = false) List<MultipartFile> TravelVisitorShoppingMallImage,
+        @Valid @RequestPart(name = "TravelVisitorTourListCreateServiceRequestDto") List<TravelVisitorTourListCreateControllerRequestDto> TravelVisitorTourListCreateControllerRequestDto,
+        @RequestPart(name = "TravelVisitorTourListImage",required = false) List<MultipartFile> TravelVisitorTourListImage,
         @AuthenticationPrincipal UserDetailsImpl userDetails) throws IOException {
         TravelCreateServiceRequestDto serviceRequestDto =
                 travelDtoMapper.toTravelCreateServiceDto(travelCreateControllerRequestDto);
@@ -61,6 +67,8 @@ public class TravelController {
             travelVisitorRestaurantDtoMapper.toTravelVisitorRestaurantCreateServiceDtos(TravelVisitorRestaurantCreateControllerRequestDto);
         List<TravelVisitorShoppingMallCreateServiceRequestDto> TravelVisitorShoppingMallCreateServiceRequestDtos =
             travelVisitorShoppingMallDtoMapper.toTravelVisitorShoppingMallCreateServiceDtos(TravelVisitorShoppingMallCreateControllerRequestDto);
+        List<TravelVisitorTourListCreateServiceRequestDto> TravelVisitorTourListCreateServiceRequestDtos =
+            travelVisitorTourListDtoMapper.toTravelVisitorTourListCreateServiceDtos(TravelVisitorTourListCreateControllerRequestDto);
         travelService.createTravel(
             serviceRequestDto,
             travelImage,
@@ -70,6 +78,8 @@ public class TravelController {
             TravelVisitorRestaurantImage,
             TravelVisitorShoppingMallCreateServiceRequestDtos,
             TravelVisitorShoppingMallImage,
+            TravelVisitorTourListCreateServiceRequestDtos,
+            TravelVisitorTourListImage,
             userDetails.user()
         );
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/com/mju/lighthouseai/domain/travel/entity/Travel.java
+++ b/src/main/java/com/mju/lighthouseai/domain/travel/entity/Travel.java
@@ -75,10 +75,10 @@ public class Travel extends BaseEntity {
   @OneToMany(mappedBy = "travel", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<TravelVisitorShoppingMall> travelVisitorShoppingMalls = new ArrayList<>();
 
-/*      @OneToMany(mappedBy = "travel", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "travel", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<TravelVisitorTourList> travelVisitorTourLists = new ArrayList<>();
 
-    @OneToMany(mappedBy = "travel", cascade = CascadeType.ALL, orphanRemoval = true)
+/*      @OneToMany(mappedBy = "travel", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<TravelVisitorOtherServiceEntity> travelVisitorOtherServiceEntities = new ArrayList<>();*/
 
     @Builder

--- a/src/main/java/com/mju/lighthouseai/domain/travel/service/TravelService.java
+++ b/src/main/java/com/mju/lighthouseai/domain/travel/service/TravelService.java
@@ -7,6 +7,7 @@ import com.mju.lighthouseai.domain.travel_visitor_cafe.dto.service.request.Trave
 import com.mju.lighthouseai.domain.travel_visitor_restaurant.dto.service.request.TravelVisitorRestaurantCreateServiceRequestDto;
 import com.mju.lighthouseai.domain.travel_visitor_restaurant.entity.TravelVisitorRestaurant;
 import com.mju.lighthouseai.domain.travel_visitor_shoppingmall.dto.service.request.TravelVisitorShoppingMallCreateServiceRequestDto;
+import com.mju.lighthouseai.domain.travel_visitor_tour_list.dto.service.request.TravelVisitorTourListCreateServiceRequestDto;
 import com.mju.lighthouseai.domain.user.entity.User;
 import java.io.IOException;
 import java.util.List;
@@ -22,6 +23,8 @@ public interface TravelService {
         List<MultipartFile> travelVisitorRestaurantImage,
         final List<TravelVisitorShoppingMallCreateServiceRequestDto> travelVisitorShoppingMallCreateServiceRequestDtos,
         final List<MultipartFile> travelVisitorShoppingMallImages,
+        final List<TravelVisitorTourListCreateServiceRequestDto> travelVisitorTourListCreateServiceRequestDtos,
+        final List<MultipartFile> travelVisitorTourListImages,
         User user
     ) throws IOException ;
     void updateTravel(Long id, TravelUpdateServiceRequestDto requestDto, User user,MultipartFile multipartFile) throws IOException;

--- a/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/controller/TravelVisitorTourListController.java
+++ b/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/controller/TravelVisitorTourListController.java
@@ -24,6 +24,7 @@ public class TravelVisitorTourListController {
     private final TravelVisitorTourListServiceImpl travelVisitorTourListService;
     @PostMapping("/create")
     public ResponseEntity<?> createTravelVisitorTourList(
+            @PathVariable Long id,
             @RequestPart TravelVisitorTourListCreateControllerRequestDto controllerRequestDto,
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestPart MultipartFile multipartFile
@@ -31,7 +32,7 @@ public class TravelVisitorTourListController {
         TravelVisitorTourListCreateServiceRequestDto serviceRequestDto =
                 travelVisitorTourListDtoMapper.toTravelVisitorTourListCreateServiceDto(
                         controllerRequestDto);
-        travelVisitorTourListService.createTravelVisitorTourList(serviceRequestDto, userDetails.user(), multipartFile);
+        travelVisitorTourListService.createTravelVisitorTourList(id,serviceRequestDto, userDetails.user(), multipartFile);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/entity/TravelVisitorTourList.java
+++ b/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/entity/TravelVisitorTourList.java
@@ -1,6 +1,7 @@
 package com.mju.lighthouseai.domain.travel_visitor_tour_list.entity;
 
 import com.mju.lighthouseai.domain.tour_list.entity.TourList;
+import com.mju.lighthouseai.domain.travel.entity.Travel;
 import com.mju.lighthouseai.domain.user.entity.User;
 import com.mju.lighthouseai.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -40,6 +41,10 @@ public class TravelVisitorTourList extends BaseEntity {
     @JoinColumn(name = "tourlist_id", nullable = false)
     private TourList tourList;
 
+    @ManyToOne
+    @JoinColumn(name = "travel_id",nullable = false)
+    private Travel travel;
+
     public TravelVisitorTourList(
             final String image_url,
             final int price,
@@ -47,7 +52,8 @@ public class TravelVisitorTourList extends BaseEntity {
             final String closetime,
             final String location,
             final User user,
-            final TourList tourList
+            final TourList tourList,
+            final Travel travel
     ) {
         this.image_url = image_url;
         this.price = price;
@@ -56,6 +62,7 @@ public class TravelVisitorTourList extends BaseEntity {
         this.location = location;
         this.user = user;
         this.tourList = tourList;
+        this.travel = travel;
     }
 
     public void updateTravelVisitorTourList(

--- a/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/mapper/dto/TravelVisitorTourListDtoMapper.java
+++ b/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/mapper/dto/TravelVisitorTourListDtoMapper.java
@@ -4,6 +4,7 @@ import com.mju.lighthouseai.domain.travel_visitor_tour_list.dto.controller.Trave
 import com.mju.lighthouseai.domain.travel_visitor_tour_list.dto.controller.TravelVisitorTourListUpdateControllerRequestDto;
 import com.mju.lighthouseai.domain.travel_visitor_tour_list.dto.service.request.TravelVisitorTourListCreateServiceRequestDto;
 import com.mju.lighthouseai.domain.travel_visitor_tour_list.dto.service.request.TravelVisitorTourListUpdateServiceRequestDto;
+import java.util.List;
 import org.mapstruct.Mapper;
 
 import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
@@ -13,8 +14,10 @@ public interface TravelVisitorTourListDtoMapper {
     TravelVisitorTourListCreateServiceRequestDto toTravelVisitorTourListCreateServiceDto(
             TravelVisitorTourListCreateControllerRequestDto controllerRequestDto
     );
-
     TravelVisitorTourListUpdateServiceRequestDto toTravelVisitorTourListUpdateServiceDto(
             TravelVisitorTourListUpdateControllerRequestDto controllerRequestDto
+    );
+    List<TravelVisitorTourListCreateServiceRequestDto> toTravelVisitorTourListCreateServiceDtos(
+      List<TravelVisitorTourListCreateControllerRequestDto> controllerRequestDtos
     );
 }

--- a/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/mapper/service/TravelVisitorTourListEntityMapper.java
+++ b/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/mapper/service/TravelVisitorTourListEntityMapper.java
@@ -19,6 +19,7 @@ public interface TravelVisitorTourListEntityMapper {
     @Mapping(source = "requestDto.opentime", target = "opentime")
     @Mapping(source = "requestDto.closetime", target = "closetime")
     @Mapping(source = "requestDto.location", target = "location")
+    @Mapping(source = "image_url", target = "image_url")
     @Mapping(source = "tourList", target = "tourList")
     @Mapping(source = "travel",target = "travel")
     TravelVisitorTourList toTravelVisitorTourList(TravelVisitorTourListCreateServiceRequestDto requestDto,

--- a/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/mapper/service/TravelVisitorTourListEntityMapper.java
+++ b/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/mapper/service/TravelVisitorTourListEntityMapper.java
@@ -1,6 +1,7 @@
 package com.mju.lighthouseai.domain.travel_visitor_tour_list.mapper.service;
 
 import com.mju.lighthouseai.domain.tour_list.entity.TourList;
+import com.mju.lighthouseai.domain.travel.entity.Travel;
 import com.mju.lighthouseai.domain.travel_visitor_tour_list.dto.service.request.TravelVisitorTourListCreateServiceRequestDto;
 import com.mju.lighthouseai.domain.travel_visitor_tour_list.dto.service.response.TravelVisitorTourListReadAllServiceResponseDto;
 import com.mju.lighthouseai.domain.travel_visitor_tour_list.entity.TravelVisitorTourList;
@@ -19,8 +20,9 @@ public interface TravelVisitorTourListEntityMapper {
     @Mapping(source = "requestDto.closetime", target = "closetime")
     @Mapping(source = "requestDto.location", target = "location")
     @Mapping(source = "tourList", target = "tourList")
+    @Mapping(source = "travel",target = "travel")
     TravelVisitorTourList toTravelVisitorTourList(TravelVisitorTourListCreateServiceRequestDto requestDto,
-                                                  User user, TourList tourList, String image_url);
+        String image_url, User user, TourList tourList, Travel travel);
 
     default String toUserName(User user){
         return user.getNickname();

--- a/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/service/TravelVisitorTourListService.java
+++ b/src/main/java/com/mju/lighthouseai/domain/travel_visitor_tour_list/service/TravelVisitorTourListService.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.util.List;
 
 public interface TravelVisitorTourListService {
-    void createTravelVisitorTourList(TravelVisitorTourListCreateServiceRequestDto requestDto, User user,
+    void createTravelVisitorTourList(Long id,TravelVisitorTourListCreateServiceRequestDto requestDto, User user,
                                      MultipartFile multipartFile) throws IOException;
 
     void updateTravelVisitorTourList(Long id, TravelVisitorTourListUpdateServiceRequestDto requestDto,


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) `#이슈번호, #이슈번호`</br>
> 해당 PR이 닫힐 때, 이슈도 닫히게 하고싶다면? ex) `close #이슈번호, #이슈번호`

- close #112 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 여행지를 생성할 때, 여행지 방문지 관광지도 함께 생성할 수 있게 코드를 수정 및 추가하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
